### PR TITLE
feat: implement git-client using the git2 lib

### DIFF
--- a/git-client/Cargo.toml
+++ b/git-client/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.17"
+git2 = "0.16.1"

--- a/git-client/src/lib.rs
+++ b/git-client/src/lib.rs
@@ -41,8 +41,7 @@ fn get_repo() -> Result<Repository, Error> {
 fn get_files_list(repo: Repository) -> Result<Vec<String>, Error> {
     let statuses = repo.statuses(None).unwrap();
     let mut modified_files: Vec<String> = Vec::new();
-    let mut statuses_iter = statuses.iter();
-    while let Some(status) = statuses_iter.next() {
+    for status in statuses.iter() {
         let stat = status.index_to_workdir().unwrap().status();
         if !DELTA_WHITELIST.contains(&stat) {
             continue;

--- a/git-client/src/lib.rs
+++ b/git-client/src/lib.rs
@@ -15,8 +15,8 @@ static DELTA_WHITELIST: &'static [Delta] = &[Delta::Modified, Delta::Added];
 /// directory is not a git repository, or if the git repository
 /// is corrupted.
 ///
-/// https://libgit2.github.com/
-/// https://docs.rs/git2/latest/git2/
+/// - https://libgit2.github.com/
+/// - https://docs.rs/git2/latest/git2/
 pub fn get_changed_files() -> Result<Vec<String>, Error> {
     let repo = get_repo()?;
     log::debug!("Successfuly using repo at path : {:?}", repo.path());

--- a/git-client/src/lib.rs
+++ b/git-client/src/lib.rs
@@ -8,15 +8,15 @@ use git2::{Repository, Error, Delta};
 static DELTA_WHITELIST: &'static [Delta] = &[Delta::Modified, Delta::Added];
 
 
-// Uses git2 to get the list of changed files
-//
-// As git2 is a library around the libgit2 C library,
-// it can raises some errors. Like if the current working
-// directory is not a git repository, or if the git repository
-// is corrupted.
-//
-// https://libgit2.github.com/
-// https://docs.rs/git2/latest/git2/
+/// Uses git2 to get the list of changed files
+///
+/// As git2 is a library around the libgit2 C library,
+/// it can raises some errors. Like if the current working
+/// directory is not a git repository, or if the git repository
+/// is corrupted.
+///
+/// https://libgit2.github.com/
+/// https://docs.rs/git2/latest/git2/
 pub fn get_changed_files() -> Result<Vec<String>, Error> {
     let repo = get_repo()?;
     log::debug!("Successfuly using repo at path : {:?}", repo.path());
@@ -28,16 +28,16 @@ pub fn get_changed_files() -> Result<Vec<String>, Error> {
 // privates functions
 // ------------------
 
-// Repository::discover will try to locate the git repository
-// starting from the working directory and going up to the root
-// If no directory is found, it will return an error.
+/// Repository::discover will try to locate the git repository
+/// starting from the working directory and going up to the root
+/// If no directory is found, it will return an error.
 fn get_repo() -> Result<Repository, Error> {
     Repository::discover(Path::new("."))
 }
 
-// Returns the list of files that have a status in the DELTA_WHITELIST
-//
-// https://docs.rs/git2/latest/git2/enum.Delta.html
+/// Returns the list of files that have a status in the DELTA_WHITELIST
+///
+/// https://docs.rs/git2/latest/git2/enum.Delta.html
 fn get_files_list(repo: Repository) -> Result<Vec<String>, Error> {
     let statuses = repo.statuses(None).unwrap();
     let mut modified_files: Vec<String> = Vec::new();

--- a/git-client/src/lib.rs
+++ b/git-client/src/lib.rs
@@ -1,3 +1,54 @@
-pub fn get_changed_files() -> Vec<String> {
-    
+use log;
+use std::path::Path;
+
+use git2::{Repository, Error, Delta};
+
+
+
+static DELTA_WHITELIST: &'static [Delta] = &[Delta::Modified, Delta::Added];
+
+
+// Uses git2 to get the list of changed files
+//
+// As git2 is a library around the libgit2 C library,
+// it can raises some errors. Like if the current working
+// directory is not a git repository, or if the git repository
+// is corrupted.
+//
+// https://libgit2.github.com/
+// https://docs.rs/git2/latest/git2/
+pub fn get_changed_files() -> Result<Vec<String>, Error> {
+    let repo = get_repo()?;
+    log::debug!("Successfuly using repo at path : {:?}", repo.path());
+    let modified_files = get_files_list(repo)?; 
+    Ok(modified_files)
+}
+
+
+// privates functions
+// ------------------
+
+// Repository::discover will try to locate the git repository
+// starting from the working directory and going up to the root
+// If no directory is found, it will return an error.
+fn get_repo() -> Result<Repository, Error> {
+    Repository::discover(Path::new("."))
+}
+
+// Returns the list of files that have a status in the DELTA_WHITELIST
+//
+// https://docs.rs/git2/latest/git2/enum.Delta.html
+fn get_files_list(repo: Repository) -> Result<Vec<String>, Error> {
+    let statuses = repo.statuses(None).unwrap();
+    let mut modified_files: Vec<String> = Vec::new();
+    let mut statuses_iter = statuses.iter();
+    while let Some(status) = statuses_iter.next() {
+        let stat = status.index_to_workdir().unwrap().status();
+        if !DELTA_WHITELIST.contains(&stat) {
+            continue;
+        }
+        let path = status.path().unwrap();
+        modified_files.push(path.to_string());
+    }
+    Ok(modified_files)
 }


### PR DESCRIPTION
Adding the git2 dependency to list the modified files.

BREAKING: changing the return value of `git_client::get_changed_files` from `Vec<String>` to `Result<Vec<String>, Error>` to allow future filter of the errors