### PR TITLE
feat: run clippy fmt and improve the exec command

### DIFF
--- a/.hooks/pre-commit.json
+++ b/.hooks/pre-commit.json
@@ -1,7 +1,13 @@
 {
-  "steps": [{
-    "name": "echoer",
-    "command": "echo $VAR world"
-  }],
-  "preCommand": "export VAR='hello'"
+  "steps": [
+    {
+      "name": "clippy",
+      "command": "cargo clippy --all-targets --all-features -- -D warnings"
+    },
+    {
+      "name": "fmt",
+      "command": "cargo fmt --check"
+    }
+  ],
+  "preCommand": "export RUST_LOG=debug"
 }

--- a/cli/.hooks/pre-commit.json
+++ b/cli/.hooks/pre-commit.json
@@ -1,6 +1,8 @@
 {
-  "steps": [{
-      "name": "echoer",
-      "command": "echo \"hello word !\""
-  }]
+  "steps": [
+    {
+      "name": "test CLI",
+      "command": "cargo test"
+    }
+  ]
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,3 @@
-use walker;
-use runner;
-use log;
 use env_logger::{Builder, Env};
 
 fn main() {
@@ -9,22 +6,15 @@ fn main() {
     let steps_collections = walker::walk("**/.hooks/pre-commit.json");
     for steps_collection in steps_collections {
         log::info!("{:?}", steps_collection);
-        
+
         let pre_command = match steps_collection.pre_command {
-            Some(x) => {
-                x + " && "
-            },
-            None => {
-                "".to_string()
-            }
+            Some(x) => x + " && ",
+            None => "".to_string(),
         };
 
         for step in steps_collection.steps {
             let final_command = pre_command.clone() + &step.command;
-            log::info!("{:?}", final_command);
-            runner::execute(&final_command)
+            runner::execute(&final_command);
         }
     }
-
-    
 }

--- a/git-client/src/lib.rs
+++ b/git-client/src/lib.rs
@@ -1,12 +1,8 @@
-use log;
 use std::path::Path;
 
-use git2::{Repository, Error, Delta};
+use git2::{Delta, Error, Repository};
 
-
-
-static DELTA_WHITELIST: &'static [Delta] = &[Delta::Modified, Delta::Added];
-
+static DELTA_WHITELIST: &[Delta] = &[Delta::Modified, Delta::Added];
 
 /// Uses git2 to get the list of changed files
 ///
@@ -20,13 +16,9 @@ static DELTA_WHITELIST: &'static [Delta] = &[Delta::Modified, Delta::Added];
 pub fn get_changed_files() -> Result<Vec<String>, Error> {
     let repo = get_repo()?;
     log::debug!("Successfuly using repo at path : {:?}", repo.path());
-    let modified_files = get_files_list(repo)?; 
+    let modified_files = get_files_list(repo)?;
     Ok(modified_files)
 }
-
-
-// privates functions
-// ------------------
 
 /// Repository::discover will try to locate the git repository
 /// starting from the working directory and going up to the root

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -1,8 +1,17 @@
-use subprocess::Exec;
-use log::info;
+use log::{debug, error};
+use subprocess::{Exec, Redirection, ExitStatus};
 
-pub fn execute(cmdstr: &String) {
-    let result = Exec::shell(cmdstr).capture().expect("Sub process failed");
-    info!("{:?}", result.exit_status);
-    info!("{:?}", result.stdout_str());
+pub fn execute(cmdstr: &String) -> bool {
+    debug!("Executing: `{}`", cmdstr);
+    let result = Exec::shell(cmdstr)
+        .stdout(Redirection::Pipe)
+        .stderr(Redirection::Merge)
+        .capture()
+        .expect("Sub process failed");
+
+    if result.exit_status != ExitStatus::Exited(0) {
+        error!("Command failed: `{}`:\n{}", cmdstr, result.stdout_str());
+        return false;
+    }
+    true
 }

--- a/walker/src/lib.rs
+++ b/walker/src/lib.rs
@@ -1,7 +1,6 @@
 mod loader;
 mod processor;
 
-
 use glob::glob;
 
 pub fn walk(pattern: &str) -> Vec<processor::StepsCollection> {
@@ -15,5 +14,5 @@ pub fn walk(pattern: &str) -> Vec<processor::StepsCollection> {
             Err(e) => println!("{:?}", e),
         }
     }
-    return steps_collections;
+    steps_collections
 }

--- a/walker/src/loader.rs
+++ b/walker/src/loader.rs
@@ -1,4 +1,3 @@
-use serde;
 use std::{error::Error, fs::File, io::BufReader, path::PathBuf};
 
 #[derive(serde::Deserialize, Debug)]
@@ -14,7 +13,7 @@ pub struct RawStep {
     /**
      *  A pattern string describing which changed files will trigger this step
      */
-    #[serde(rename="onlyOn")]
+    #[serde(rename = "onlyOn")]
     pub only_on: Option<String>,
     /**
      *  Should this step be awaited before starting the next one
@@ -35,7 +34,7 @@ pub struct RawStepsCollection {
     /**
      * A boolean denoting whether a virtualenv is started of not for this hook (eg for Python)
      */
-    #[serde(rename="preCommand")]
+    #[serde(rename = "preCommand")]
     pub pre_command: Option<String>,
 }
 

--- a/walker/src/processor.rs
+++ b/walker/src/processor.rs
@@ -2,14 +2,14 @@ use crate::loader::RawStepsCollection;
 
 #[derive(Debug)]
 pub struct Step {
-  /**
-   *  The named of the step. Displayed in the UI and used in it to index steps and hooks
-   */
-  pub name: String,
-  /**
-   *  The command that will be invoked
-   */
-  pub command: String
+    /**
+     *  The named of the step. Displayed in the UI and used in it to index steps and hooks
+     */
+    pub name: String,
+    /**
+     *  The command that will be invoked
+     */
+    pub command: String,
 }
 
 #[derive(Debug)]
@@ -21,22 +21,22 @@ pub struct StepsCollection {
     /**
      * A boolean denoting whether a virtualenv is started of not for this hook (eg for Python)
      */
-    pub pre_command: Option<String>
+    pub pre_command: Option<String>,
 }
 
 pub fn process_from_raw_collection(raw_steps: &RawStepsCollection) -> StepsCollection {
-  let mut steps: Vec<Step> = Vec::new();
+    let mut steps: Vec<Step> = Vec::new();
 
-  for raw_step in raw_steps.steps.as_slice() {
-    let step = Step {
-      name: raw_step.name.clone(),
-      command: raw_step.command.clone()
-    };
-    steps.push(step)
-  }
+    for raw_step in raw_steps.steps.as_slice() {
+        let step = Step {
+            name: raw_step.name.clone(),
+            command: raw_step.command.clone(),
+        };
+        steps.push(step)
+    }
 
-  return StepsCollection { 
-    steps, 
-    pre_command: raw_steps.pre_command.clone()
-  };
+    StepsCollection {
+        steps,
+        pre_command: raw_steps.pre_command.clone(),
+    }
 }


### PR DESCRIPTION
# Format

Using clippy and cargo fmt to format the code :

```bash
$ cargo clippy
$ cargo fmt
```

I've also added them to the `.hooks/pre-commit.json` file.

# Capture command output

The basic `.capture` did not capture `stderr`. I've added two lines to merge the two streams.

It merges them in the right order and preserve colors :

![image](https://user-images.githubusercontent.com/32516498/218284190-9577af00-ea6c-4aa0-a10e-78fad4aef75f.png)
